### PR TITLE
「サイドバー」と「実装例で必要なもの」の更新

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,8 +1,8 @@
-- はじめに
+- WoTについて
   - [Web of Thingsについて](about.md)
   - [WoT-JP CGについて](aboutcg.md)
 
-- デプロイメント
+- ドキュメント
   - WoT入門
     - [WoTの基本的なシーケンス](basicsequence.md)
   - チュートリアル
@@ -10,24 +10,19 @@
       - [RaspberryPiでThingを作る](raspithing.md)
     - Thingの利用
       - [Node Generator for Node-REDを使ったThingの操作](nodegen-tutorial.md)
-  - 例
-    - Raspberry Pi
-      - [気圧センサー BMP280](examples/bmp280/)
-      - [温湿度センサー SHT3x](examples/sht3x/)
-    - スマート家電（APIの利用）
-      - [Hue 電球 ホワイトグラデーション](examples/hue-white-light/)
-      - [SwitchBot 開閉センサー](examples/switchbot-contact-sensor/)
-    - ロボット（Python APIの利用）
-      - [ロボットアーム myCobot 280](examples/mycobot/)
 
-- アウトリーチ
-  - [CG関連イベント](event.md)
+- 実装例
+  - センサーのWoT化
+    - [気圧センサー (BMP280 + Raspberry Pi)](examples/bmp280/)
+    - [温湿度センサー (SHT3x + Raspberry Pi)](examples/sht3x/)
+  - IoTデバイス (REST APIが取得可能) のWoT化
+    - [Hue (電球 ホワイトグラデーション)](examples/hue-white-light/)
+    - [SwitchBot (開閉センサー)](examples/switchbot-contact-sensor/)
+  - 外部フレームワークを利用したWoT化
+    - [ロボットアーム (WoTPy × myCobot 280)](examples/mycobot/)
 
-- ダウンストリーム
-  - [WoT勧告の翻訳](translation.md)
-
-- 関連文書
-  - [W3C勧告など](recs.md)
+- WoT仕様
+  - [WoT仕様の全体像](recs.md)
 
 - [その他・リンク集](misc.md)
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,4 +1,4 @@
-- WoTについて
+- Web of Things (WoT)について
   - [Web of Thingsについて](about.md)
   - [WoT-JP CGについて](aboutcg.md)
 
@@ -11,7 +11,7 @@
     - Thingの利用
       - [Node Generator for Node-REDを使ったThingの操作](nodegen-tutorial.md)
 
-- 実装例
+- Thingの実装例
   - センサーのWoT化
     - [気圧センサー (BMP280 + Raspberry Pi)](examples/bmp280/)
     - [温湿度センサー (SHT3x + Raspberry Pi)](examples/sht3x/)

--- a/docs/examples/bmp280/README.md
+++ b/docs/examples/bmp280/README.md
@@ -3,6 +3,16 @@
 [BOSCH 気圧センサー BMP280](https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp280/) のための Thing です。
 Node-RED とノードモジュール [node-red-contrib-bme280](https://www.npmjs.com/package/node-red-contrib-bme280) を使用します。
 
+### 必要なもの
+- ハードウェア
+  - Raspberry Pi 3以降
+  - [BOSCH 気圧センサー BMP280](https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp280/)
+  - ジャンパワイヤ、ブレッドボードなど
+- ソフトウェア
+  - [Node-RED v2.0 以降](https://nodered.org/)
+  - [BME280制御用ノードモジュール (node-red-contrib-bme280)](https://flows.nodered.org/node/node-red-contrib-bme280)
+  - [Node Generator (node-red-nodegen)](https://github.com/node-red/node-red-nodegen)
+
 ## 配線図
 
 I<sup>2</sup>C を利用して下記の図のように接続します。

--- a/docs/examples/hue-white-light/README.md
+++ b/docs/examples/hue-white-light/README.md
@@ -5,6 +5,15 @@
 
 本サンプルでは、REST API が既に用意されており、エンドポイントを決め、API の URL を Thing Description、ノードモジュールへと対応づける例として、 Hue を取り上げ WoT 化を行います。  
 
+### 必要なもの
+- ハードウェア
+  - [Philips Hue ブリッジ](https://www.philips-hue.com/ja-jp/p/hue-bridge/8719514342460)
+  - [Philips Hue スマート電球 ホワイトグラデーション](https://www.philips-hue.com/ja-jp/p/hue-white-ambiance-1-pack-e26/8718699722302)
+  - Hueと同一のネットワーク上にあるPCやRaspberry Piなど
+- ソフトウェア
+  - [Node-RED v2.0 以降](https://nodered.org/)
+  - [Node Generator (node-red-nodegen)](https://github.com/node-red/node-red-nodegen)
+
 ## Hueのセットアップ
 
 公式の開発者ページ
@@ -162,3 +171,14 @@ Thing Description の`actions`の一部を引用し注目すると、電球の�
 - Form: `nosec http://...`
 
 ![使用例](hue-white-light-action.png)
+
+## 応用例 (ディマースイッチ・ブリッジ)
+
+同様の手順で、
+[Hue ディマースイッチ](https://www.philips-hue.com/ja-jp/p/hue-dimmer-switch--latest-model-/8719514274655)や
+[Hue ブリッジ](https://www.philips-hue.com/ja-jp/p/hue-bridge/8719514342460)
+をThingとして扱うことができます。  
+下記の[WoTify](https://wotify.org/ )にある Thing Description を元に、それぞれWoT化が可能です。
+
+- [Philips HUE Dimmer Switch の Thing Description](https://wotify.org/library/Philips%20HUE%20Dimmer%20Switch/general)
+- [Philips HUE Bridge の Thing Description](https://wotify.org/library/Philips%20HUE%20Bridge/general)

--- a/docs/examples/mycobot/README.md
+++ b/docs/examples/mycobot/README.md
@@ -5,6 +5,15 @@
 
 本サンプルでは、[WoTPy](https://github.com/agmangas/wot-py) を使用して既存の Python API を Restful API として操作出来るようにする例として、[myCobot](https://www.elephantrobotics.com/en/mycobot-en/) を取り上げ WoT 化 を行います。
 
+### 必要なもの
+- ハードウェア
+  - [myCobot 280](https://www.elephantrobotics.com/en/mycobot-en/)
+  - PCやRaspberry Piなど
+- ソフトウェア
+  - Python 3.7 以降
+  - [WoTPy (wotpy 0.16.0)](https://github.com/agmangas/wot-py)
+  - [pymycobot (2.6.1)](https://github.com/elephantrobotics/pymycobot)
+
 なお本サンプルでは、試験的実装段階の [WoTPy](https://github.com/agmangas/wot-py) を使用しているため、最新の情報や変更にご注意の上、ご利用ください。
 本サンプルでは、wotpy 0.16.0, pymycobot 2.6.1 を使用しています。  
 最新の情報や詳細は、[WoTPy GitHub](https://github.com/agmangas/wot-py) や [WoTPy のドキュメント](https://agmangas.github.io/wot-py/)をご確認ください。

--- a/docs/examples/sht3x/README.md
+++ b/docs/examples/sht3x/README.md
@@ -3,6 +3,16 @@
 [Sensirion 温湿度センサー SHT3x シリーズ](https://www.sensirion.com/jp/environmental-sensors/humidity-sensors/digital-humidity-sensors-for-various-applications/)のための Thing です。
 Node-RED とノードモジュール [node-red-contrib-sht31](https://www.npmjs.com/package/node-red-contrib-sht31) を使用します。
 
+### 必要なもの
+- ハードウェア
+  - Raspberry Pi 3以降
+  - [Sensirion 温湿度センサー SHT3x シリーズ](https://www.sensirion.com/jp/environmental-sensors/humidity-sensors/digital-humidity-sensors-for-various-applications/)
+  - ジャンパワイヤ、ブレッドボードなど
+- ソフトウェア
+  - [Node-RED v2.0 以降](https://nodered.org/)
+  - [SHT3x制御用ノードモジュール (node-red-contrib-sht31)](https://flows.nodered.org/node/node-red-contrib-sht31)
+  - [Node Generator (node-red-nodegen)](https://github.com/node-red/node-red-nodegen)
+
 ## 配線図
 
 I<sup>2</sup>C を利用して下記の図のように接続します。

--- a/docs/examples/switchbot-contact-sensor/README.md
+++ b/docs/examples/switchbot-contact-sensor/README.md
@@ -4,6 +4,17 @@
 
 本サンプルでは、REST API が既に用意されているものから、Thing Description を作成し、ノードモジュールへと対応づける例として、 SwitchBot を取り上げ WoT 化を行います。  
 
+### 必要なもの
+- ハードウェア
+  - SwitchBot Hub Plus または [Hub Mini](https://www.switchbot.jp/collections/all/products/switchbot-hub-mini)
+  - [SwitchBot開閉センサー](https://www.switchbot.jp/collections/all/products/contact-sensor)
+  - スマートフォン
+  - PCやRaspberry Piなど
+- ソフトウェア
+  - [SwitchBot アプリ](https://www.switchbot.jp/)
+  - [Node-RED v2.0 以降](https://nodered.org/)
+  - [Node Generator (node-red-nodegen)](https://github.com/node-red/node-red-nodegen)
+
 ## SwitchBotハブのセットアップ
 
 [SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBotAPI) のページに従い進めていきます。  


### PR DESCRIPTION
#42 のサイト再編案にて議論されています、サイドバーの更新と実装例で必要なもののリスト追加の提案です。
再編案にて議論されています、サイドバーに更新し、実装例については、下記のような用途ごとに分類したものとしました。
- 実装例
  - センサーのWoT化
    - 気圧センサー (BMP280 + Raspberry Pi)
    - 温湿度センサー (SHT3x + Raspberry Pi)
  - IoTデバイス (REST APIが取得可能) のWoT化
    - Hue (電球 ホワイトグラデーション)
    - SwitchBot (開閉センサー)
  - 外部フレームワークを利用したWoT化
    - ロボットアーム (WoTPy × myCobot 280)

また、実装例で必要なものを、それぞれの例の冒頭に付け加えました。
   
ご確認、よろしくお願いいたします。