### PR TITLE
WoT-JP CG の説明ページの更新

### DIFF
--- a/docs/aboutcg.md
+++ b/docs/aboutcg.md
@@ -1,21 +1,65 @@
 # Web of Things Japanese Community Groupについて
+Web of Things Japanese Community Group (WoT-JP CG) は、
 
-Web of Things Japanese Community Groupは、
-
-- Web of Things標準技術の啓蒙・利活用促進、標準化推進支援
-- Web of Thingsを用いた新ビジネスの創出の支援
-- 日本語でのコミュニケーションを基本とした持続的コミュニティの醸成
+* Web of Things標準技術の啓蒙・利活用促進、標準化推進支援
+* Web of Thingsを用いた新ビジネスの創出の支援
+* 日本語でのコミュニケーションを基本とした持続的コミュニティの醸成
 
 を目的として、2021年1月に設立されました。
 
-上記の目的の達成のために、下記の活動を計画しています。
+## WoT-JP CG の活動内容
+現在は活動目的を叶えるために、以下のタスクフォースを作り、それぞれの目的に応じて活動をしています。
 
-- IoT動向などに関する参加者相互の情報交換・意見交換の場の設置
-- Web of Thingsに関する勉強会、ハッカソン、アイディアソン等のイベントの開催
-- Web of Things開発者コミュニティにむけた情報提供
-- 活動から得られた知見のW3C Web of Things Interest/Working Group等への提供
+![WoT-JP CG の活動](https://user-images.githubusercontent.com/80234020/156139159-854f5d05-a450-417d-a7ea-30c8b657bfc1.png)
 
+各タスクフォースの活動内容です。
+更に詳細な活動内容はリンク先の TF活動提案書もご覧ください。
 
-参加申し込みは[Web of Things Japanese Community Groupのウェルカムページ](https://www.w3.org/community/wot-jp/)から行えます。Web of Thingsに関心があるかたの参加をお待ちしております。
+### [デプロイメントTF](https://github.com/w3c/wot-jp-cg/tree/main/TF/Deployment)
+* 概要
+	* Web of Thingsを実装するために必要な日本語の技術資料の充実
+* モデレータ
+	* 東村邦彦 (日立製作所)
+* 目的
+	* IoTシステムを実装しようと考えている開発者が自らの手でWoTを適用できるように、具体例を含む導入資料を充実させる
 
-参考: [Community GroupのDraft Charter](CGCharter.html ":ignore")
+### [アウトリーチTF](https://github.com/w3c/wot-jp-cg/tree/main/TF/Outreach)
+* 概要
+	* W3C WoT規格の普及に向けて、国内の団体・企業・開発者コミュニティへの啓蒙活動、他標準化団体とのリエゾン活動を行う
+* モデレータ
+	* 安次富大介（東芝）
+* 目的
+	* W3C WoT規格の認知度向上と普及。認知度向上に関しては、特に、非Web/IT企業、W3C規格になじみのない産業領域へのアプローチを行う
+	* 普及に関しては、ボトムアップの開発者コミュニティに加え、潜在的にWoT規格を採択し得る他標準化団体もターゲットとする
+### [ユースケースTF](https://github.com/w3c/wot-jp-cg/tree/main/TF/Usecases)
+* 概要
+	* WoTの社会実装に向けた、日本発のユースケースや実装例の創出
+* モデレータ
+	* 水嶌友昭 (IRI)
+* 目的
+    * WoT標準普及に向けて、「どのような産業において、WoT標準がどう役立つか」という観点でユースケースを検討することにより、CG参加者のWoTへの理解を深めるとともに、WoTを産業応用する際の課題に関して整理する
+        * 日本の産業界発信で，新しいWoTユースケースの抽出，要件の明確化，Gap分析に取り組むための方針明確化
+        * ユースケースを提案した参加者はWoTを利用した場合の疑問点を解消しやすくなる
+        * ユースケースが充実すると、WoTの利用、及び応用の検討がしやすくなる
+        * 検討されたユースケースや要件定義がWoT WG/IGに提案され、機能追加等、標準化作業にフィードバックされる
+
+### [翻訳TF](https://github.com/w3c/wot-jp-cg/tree/main/TF/Translation)
+* 概要
+	* WoT活動の普及促進のためにWoT関連情報を翻訳 (英日/日英)
+* モデレータ
+	* 芦村和幸 (W3C/慶應)
+* 目的
+	* 日本人コミュニティに対して，WoT IG/WGでの英語議論を周知するとともに，WoT IG/WGへ，日本側での議論を英語で共有する
+
+## WoT-JP CG と WoT WG/IG との関係
+
+それぞれの活動で得た情報の交換、提案、作業貢献などで相互連携が出来るように活動をしております。
+[W3C WoT サイト](https://www.w3.org/WoT/cg/)にも WoT-JP CG の紹介が掲載されています。
+
+![WoT-JP CG と WoT WG/IG との関係](https://user-images.githubusercontent.com/80234020/156139326-d73c6ad1-f9d3-4134-abb2-c6b36305b747.png)
+
+## WoT-JP CG への参加方法
+
+参加申し込みは [Web of Things Japanese Community Group のウェルカムページ](https://www.w3.org/community/wot-jp/)から行えます。Web of Thingsに関心があるかたの参加をお待ちしております。
+
+参考: [Community Group の Draft Charter](https://wot-jp-cg.netlify.app/CGCharter.html)


### PR DESCRIPTION
#53 にて提案されている CG の説明ページを更新しています。
- CGの建付けの分かる図の追加と、4つのTFの概要説明を追加。
- W3C WoT WG/IG との関係性の図の追加。

直近の 3/11 に開催される CG イベント前に整えられればと思い更新しましたので、確認いただければと思います。
あくまでたたき台としていただき、加筆修正を加えていただければと思いますので、よろしくお願いします。