### PR TITLE
開催済イベント資料・情報、リンクの追加

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -26,7 +26,9 @@
   - [WoT仕様の全体像](recs.md)
   - [WoT Thing Descriptionとは](td.md)
 
-- [その他・リンク集](misc.md)
+- その他・リンク集・イベント資料
+  - [イベント情報・資料 (開催済)](event.md)
+  - [その他・リンク集](misc.md)
 
 ---
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -72,3 +72,9 @@ Thing Descriptionを人が読んで理解して、アクセスするためのプ
 Thingを扱うことが可能になります。
 
 以上のように、Thing Descriptionを介してさまざまなIoTデバイスとアプリケーションをつなぎ合わせることができるのがWoTの特長です。
+
+WoTの仕様と実装、WoTの作り方/使い方については、こちらのスライドも参考としてご覧ください。
+
+<iframe src="https://docs.google.com/viewer?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwot-jp-cg%2Fmain%2FEvent%2F20220311_3rd_WoT_and_ELWA_Study_Meeting%2F20220311-WoT-JP_CG-ktoumura.pdf&embedded=true" width="100%" height="500px"></iframe>
+
+[第3回 WoT-JP CG イベント - W3C Web of Things & ECHONET Lite Web API 勉強会 スライド資料 : WoT セッション2:WoT の仕様と実装 - WoT の作り方/使い方](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting/20220311-WoT-JP_CG-ktoumura.pdf)

--- a/docs/event.md
+++ b/docs/event.md
@@ -1,12 +1,105 @@
 # WoT-JP CG関連イベント
 
-## 開催予定のイベント
+## 開催済 イベント情報・資料
 
-計画中
+### 第4回 WoT-JP CG イベント - オープン標準による IoT の世界 - 具体的ユースケースを踏まえて (2022.3.25)
 
-## 過去のイベント
+- [イベント情報・資料](https://github.com/w3c/wot-jp-cg/tree/main/Event/20220325_4th_WoT_Usecases_Event)
+
+1. ご挨拶 / WoT-JP CG の活動について [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220325_4th_WoT_Usecases_Event/20220325_WoT-JP_CG_Mizushima.pdf)
+2. 最新 WoT 概要 [芦村]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220325_4th_WoT_Usecases_Event/20220325-WoT-Ashimura.pdf)
+3. WoT ユースケースについて [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220325_4th_WoT_Usecases_Event/20220325-WoT_UseCases-Mizushima.pdf)
+4. WoTデモンストレーション「スマートホーム+ スマート農業をイメージしたダッシュボード/ GitHub or twitter 連携」 [浅井]
+5. 様々な WoT ユースケースの紹介
+    - ビルマネジメント [粕谷]
+    - ECHONET [松田]
+    - スマートホーム×Hybridcast [遠藤]
+6. ディスカッション [モデレータ：浅井, パネリスト：水嶌, 芦村, 粕谷, 松田, 遠藤]
+7. 閉会
+
+### 第3回 WoT-JP CG イベント - W3C Web of Things & ECHONET Lite Web API 勉強会 (2022.3.11)
+
+- [イベント情報・資料](https://github.com/w3c/wot-jp-cg/tree/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting)
+
+1. 勉強会の趣旨説明 [安次富]
+2. 開会ご挨拶 / WoT-JP CG の紹介 [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting/20220311-WoT-JP_CG_Mizushima.pdf)
+3. WoT セッション1:WoT 仕様と標準化の最新動向 [芦村]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting/20220311-WoT-JP_CG_Ashimura.pdf)
+4. WoT セッション2:WoT の仕様と実装 - WoT の作り方/使い方 [東村, 浅井]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting/20220311-WoT-JP_CG-ktoumura.pdf)
+5. ELWA セッション:ECHONET Lite Web APIの紹介 [寺本]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20220311_3rd_WoT_and_ELWA_Study_Meeting/20220311.WoT-JP_CG_ECHONET_Teramoto.pdf)
+6. 質疑応答
+7. ディスカッション [モデレータ：安次富, パネリスト：水嶌, 芦村, 東村, 浅井, 寺本]
+8. 閉会 [東村]
+
+### 第2回 WoT-JP CG全体会議 (2022.1.28)
+
+- [イベント情報・資料](https://github.com/w3c/wot-jp-cg/tree/main/Event/20220128_2nd_Main_Meeting)
+
+1. WoTの現状とビジョン [芦村]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20211222_1st_Main_Meeting/20211222-WoT-JP_CG_Ashimura.pdf)
+2. CG設立の趣旨 [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20211222_1st_Main_Meeting/20211222-WoT-JP_CG_Mizushima_20211222.pdf)
+    - [W3C - WoT CG](https://www.w3.org/WoT/cg/)
+3. 全体運営ポリシー [浅井]
+    - [WoT-JP CG - POLICY.md](https://github.com/w3c/wot-jp-cg/blob/main/POLICY.md)
+4. TF 活動紹介と作業手順
+    * Deployment [東村]
+      * [DPTF提案書](https://github.com/w3c/wot-jp-cg/tree/main/TF/Deployment)
+    * Outreach [安次富]
+      * [ORTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Outreach/README.md)
+      * [ORTFイベント提案](https://github.com/w3c/wot-jp-cg/blob/main/TF/Outreach/project_management.md)
+      * [イベント管理プロジェクト](https://github.com/w3c/wot-jp-cg/projects/1)
+      * [イベント企画提案](https://github.com/w3c/wot-jp-cg/issues/new/choose)
+    * Translation [芦村]
+      * [TRTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Translation/README.md)
+      * [WoT Architecture仕様書](https://www.w3.org/TR/2020/REC-wot-architecture-20200409/)
+      * [WoT Architecture日本語原本](https://wot-jp-community.github.io/wot-architecture/)
+      * [WoT Architecture TTC標準](https://www.ttc.or.jp/document_db/information/view_express_entity/1388)
+    * Use Cases [水嶌]
+      * [UCTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Usecases/README.md)
+5. Q&A
+
+### 第1回 WoT-JP CG全体会議 (2021.12.22)
+
+- [イベント情報・資料](https://github.com/w3c/wot-jp-cg/tree/main/Event/20211222_1st_Main_Meeting)
+
+1. WoTの現状とビジョン [芦村]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20211222_1st_Main_Meeting/20211222-WoT-JP_CG_Ashimura.pdf)
+2. CG設立の趣旨 [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20211222_1st_Main_Meeting/20211222-WoT-JP_CG_Mizushima_20211222.pdf)
+    - [W3C - WoT CG](https://www.w3.org/WoT/cg/)
+3. 全体運営ポリシー [浅井]
+    - [WoT-JP CG - POLICY.md](https://github.com/w3c/wot-jp-cg/blob/main/POLICY.md)
+4. TF 活動紹介と作業手順
+    * Deployment [東村]
+      * [DPTF提案書](https://github.com/w3c/wot-jp-cg/tree/main/TF/Deployment)
+    * Outreach [安次富]
+      * [ORTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Outreach/README.md)
+      * [ORTFイベント提案](https://github.com/w3c/wot-jp-cg/blob/main/TF/Outreach/project_management.md)
+      * [イベント企画提案](https://github.com/w3c/wot-jp-cg/issues/new/choose)
+    * Translation [芦村]
+      * [TRTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Translation/README.md)
+      * [WoT Architecture日本語原本](https://wot-jp-community.github.io/wot-architecture/)
+      * [WoT Architecture TTC標準](https://www.ttc.or.jp/document_db/information/view_express_entity/1388)
+    * Use Cases [水嶌]
+      * [UCTF提案書](https://github.com/w3c/wot-jp-cg/blob/main/TF/Usecases/README.md)
+5. Q&A
 
 ### Webで実現する未来のIoT ～「WoT-JP CG」設立イベント～ (2021.2.27)
 
+- [イベント情報・資料](https://github.com/w3c/wot-jp-cg/tree/main/Event/20210227_1st_Online_Event)
 - https://wot-jp-cg-20210227.peatix.com/
-- 開催報告(執筆中)
+
+1. 開会挨拶 [水嶌]
+2. 総務省挨拶 [稲森]
+3. WoT-JP CG紹介と本イベントの趣旨 [水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20210227_1st_Online_Event/About_cg.pdf)
+4. パネルセッション～WoT技術及びWoT-JP CGへの期待 [モデレータ：芦村, パネリスト：安次富, 太田, 塩濱, 木浦, 東村, 水嶌]
+    - [プレゼン資料](https://github.com/w3c/wot-jp-cg/blob/main/Event/20210227_1st_Online_Event/panel-slides.pdf)
+5. まとめと挨拶 [水嶌, 東村]


### PR DESCRIPTION
event.mdに開催済イベント情報を記載・追加する提案です。
概要として、それぞれのイベントのプログラムと資料のリンクを記載しております。
よろしくお願いいたします。