### PR TITLE
to add WoT-UseCases-Template into .github/ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
+++ b/.github/ISSUE_TEMPLATE/WoT-UseCases-Template.yml
@@ -1,0 +1,208 @@
+name: New Use Case Template 20240710
+description: This is the latest WoT Use Case Issue Template. Please use this issue template to suggest a new use case to be added to the WoT standards.
+labels: ["UC"]
+title: "Put your title for the use case."
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!Note]
+        Thank you for proposing a new use case! Use case proposals use a structured GitHub issue so that we can semi-automate the process. A bot will check the suggestion after creation, and report on missing properties or other problems before we review the suggestion.
+
+  - type: input
+    id: submitter
+    attributes:
+      label: Submitter
+      description: Please enter your name.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Motivation
+  - type: textarea
+    id: what_to_be_done
+    attributes:
+      label: "What to be done?"
+      description: |
+        Please describe any problems or improvements you would like to make in your use case.
+    validations:
+      required: true
+  - type: textarea
+    id: why_wot
+    attributes:
+      label: Why WoT? (Stakeholder's interest in using WoT)
+      description: |
+        Please describe why you would like to use WoT in your use case.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Use Case Description and Expectations for stakeholders and environments
+
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "Please describe your use case details."
+    validations:
+      required: true
+  - type: textarea
+    id: gaps
+    attributes:
+      label: Gaps between the user's need and what's possible today
+      description: |
+        Describe any gaps that are not addressed in the current WoT standards and building blocks
+    validations:
+      required: true
+  - type: checkboxes
+    id: targetusers
+    attributes:
+      label: Target Users
+      description: |
+        List all stakeholders that are involved in the use case from the following list
+      options:
+        - label: Device owners
+        - label: Device user
+        - label: Cloud provider
+        - label: Service provider
+        - label: Device manufacturer
+        - label: Gateway manufacturer
+        - label: Network operator (potentially transparent for WoT use cases)
+        - label: Identity provider
+        - label: Directory service operator
+        - label: Other (please specify)
+    validations:
+      required: true
+  - type: textarea
+    id: targetusers_custom
+    attributes:
+      label: Other Target Users
+      description: Other stakeholders
+  - type: textarea
+    id: expecteddevices
+    attributes:
+      label: Expected Devices
+      description: Please describe your expected devices for your use cases.
+    validations:
+      required: true
+  - type: textarea
+    id: expecteddata
+    attributes:
+      label: Expected Data
+      description: Please describe your expected data for your use cases.
+    validations:
+      required: true
+  - type: textarea
+    id: potentialadopters
+    attributes:
+      label: Potential Adopters
+      description: Please describe your potential adopters for your use cases.
+    validations:
+      required: true
+  - type: textarea
+    id: potentialapplications
+    attributes:
+      label: Potential Applications
+      description: Please describe your potential applications for your use cases.
+    validations:
+      required: true
+  - type: textarea
+    id: expectedprotocol
+    attributes:
+      label: Expected Protocol
+      description: Please describe your expected protocol for your use cases.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Relationships with existing resources and standards
+  - type: textarea
+    id: similarusecases
+    attributes:
+      label: Existing similar WoT use case already defined?
+      description: Please provide links
+    validations:
+      required: true
+  - type: textarea
+    id: dependenciesonwot
+    attributes:
+      label: Dependencies on WoT - Affected WoT deliverables and/or work items
+      description: |
+        List the affected WoT deliverables that have to be changed to enable this use case.
+    validations:
+      required: true
+  - type: textarea
+    id: existingw3cstandards
+    attributes:
+      label: Other WG's standards, e.g., HTML/CSS, Device APIs, DID/Verifiable Credentials, JSON-LD and RDF
+    validations:
+      required: true
+  - type: textarea
+    id: expectedrelationshipwithw3cstandards
+    attributes:
+      label: Expected relationship with Existing standards by other WGs within W3C
+      description: |
+        Refer to the existing standards (no change for WoT) / Make WoT compatible by adding new features (impact for WoT).
+    validations:
+      required: true
+  - type: textarea
+    id: existingextenalstandards
+    attributes:
+      label: Existing standards outside W3C
+    validations:
+      required: true
+  - type: textarea
+    id: expectedrelationshipwithexternalstandards
+    attributes:
+      label: Expected relationship with existing standards outside W3C
+      description: |
+        Refer to the existing standards (no change for WoT) / Make WoT compatible by adding new features (impact for WoT).
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Clarifications of user's needs<br/>(optional but to be described as specific as possible so that requirements can be extracted precisely later)
+  - type: textarea
+    id: securityconsiderations
+    attributes:
+      label: Security Considerations
+      description: |
+        Describe any issues related to security as a guide. See also the security part of [security and privacy review](https://github.com/w3c/wot-architecture/blob/main/publication/ver11/security_and_privacy.md).
+        If there are none, say "none" and justify.
+    validations:
+      required: true
+  - type: textarea
+    id: privacyconsideations
+    attributes:
+      label: Privacy Considerations
+      description: |
+        Describe any issues related to privacy as a guide. See also the privacy part of [security and privacy review](https://github.com/w3c/wot-architecture/blob/main/publication/ver11/security_and_privacy.md).
+        If there are none, say "none" and justify.
+    validations:
+      required: true
+  - type: textarea
+    id: accessibilitycosiderations
+    attributes:
+      label: Accessibility Considerations
+      description: |
+        Describe any issues related to accessibility as a guide. See also [accessibility review](https://github.com/w3c/wot-architecture/blob/main/publication/ver11/accessibility.md).
+        If there are none, say "none" and justify.
+    validations:
+      required: true
+  - type: textarea
+    id: internationalizationconsiderations
+    attributes:
+      label: Internationalization (i18n) Considerations
+      description: |
+        Describe any issues related to internationalization as a guide. See also [internationalization review](https://github.com/w3c/wot-architecture/blob/main/publication/ver11/internationalization.md).
+        If there are none, say "none" and justify.
+    validations:
+      required: true


### PR DESCRIPTION
WoT WG/IGのUseCases TFで作成されているUse Case Template (WoT-UseCases-Template.yml)をコピーしました。

オリジナルのままで、日本語化はしていません。