### PR TITLE
外部サイトのチュートリアルへのリンクを追加

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,6 +10,7 @@
       - [RaspberryPiでThingを作る](raspithing.md)
     - Thingの利用
       - [Node Generator for Node-REDを使ったThingの操作](nodegen-tutorial.md)
+    - [Node-REDでWeb of Thingsを試してみる(外部サイト)](https://qiita.com/hidekita/items/6d07452922e201c89cdf)
 
 - Thingの実装例
   - センサーのWoT化


### PR DESCRIPTION
@hidetak さんによるNode-REDを用いたThingの作成と可視化のチュートリアル( [Node-REDでWeb of Thingsを試してみる](https://qiita.com/hidekita/items/6d07452922e201c89cdf))へのリンクをサイドバーの「チュートリアル」の節に追加しました。

「その他・リンク集・イベント資料」に加える形でもよいかと思いましたが、よりたどりやすくするためにサイドバーから直接リンクという形にしています。 

1週間後の9/5まで待って、特に異論がないようでしたらこちらでマージします。